### PR TITLE
FEATURE(DB): Redesign marketplace schema with cascade rules and buyer…

### DIFF
--- a/persistence/db/schema.sql
+++ b/persistence/db/schema.sql
@@ -1,121 +1,280 @@
 -- MySQL 8.x DDL for the ER diagram (Account, Listing, Offer, Comment, Rating)
--- Notes:
--- - Account uses UUID as CHAR(36)
--- - Listing/Offer/Comment/Rating use BIGINT auto-increment IDs
--- - Relationship diamonds map to FKs:
---   * Account (1) posts Listing (M)  -> listing.seller_uuid
---   * Listing (1) has Offer (M)      -> offer.listing_id
---   * Account (1) sends Offer (M)    -> offer.sender_uuid
---   * Account (1) writes Comment (M) -> comment.author_uuid
---   * Listing (1) has Comment (M)    -> comment.listing_id
---   * Listing (1) gets Rating (M)    -> rating.listing_id
+-- This schema models a simple marketplace where:
+-- - Accounts can post listings
+-- - Other accounts can make offers on listings
+-- - Accounts can comment on listings
+-- - A listing can be sold to one buyer, and ONLY that buyer can leave ONE rating
+
+-- Notes / Design decisions:
+-- - Primary keys are BIGINT UNSIGNED AUTO_INCREMENT for compact, fast indexing and joins.
+-- - All tables use ENGINE=InnoDB to support transactions, row-level locking, and foreign keys.
+-- - Foreign keys use ON DELETE CASCADE / ON UPDATE CASCADE so deleting a parent row cleans up related rows.
+-- - TEXT is used for fields where we do not want to set an explicit maximum length.
+-- - Monetary values use DECIMAL(10,2) to avoid floating-point rounding errors.
+-- - Timestamps default to CURRENT_TIMESTAMP for automatic creation time capture.
+
+-- Relationship mappings (cardinality + FK columns):
+-- * Account (1) posts Listing (M)
+--     listing.seller_id → account.id
+--
+-- * Listing (1) has Offer (M)
+--     offer.listing_id → listing.id
+--
+-- * Account (1) sends Offer (M)
+--     offer.sender_id → account.id
+--
+-- * Listing (1) has Comment (M)
+--     comment.listing_id → listing.id
+--
+-- * Account (1) writes Comment (M)
+--     comment.author_id → account.id
+--
+-- * Listing (1) gets Rating (0..1)  (one rating per listing, because one buyer)
+--     rating.listing_id → listing.id   (UNIQUE on listing_id enforces at most one rating per listing)
+--
+-- * Account (1) gives Rating (M)
+--     rating.rater_id → account.id
+--
+-- * Listing (0..1) is sold to Account (0..M)
+--     listing.sold_to_id → account.id
+
+-- Deletion behavior (due to ON DELETE CASCADE):
+-- - Deleting an Account deletes:
+--     • Listings they posted (and all offers/comments/ratings under those listings)
+--     • Offers they sent
+--     • Comments they wrote
+--     • Ratings they made
+--     • Listings where they were the buyer (sold_to_id) will also be deleted (since it cascades)
+--
+-- - Deleting a Listing deletes:
+--     • All offers on that listing
+--     • All comments on that listing
+--     • The rating on that listing (if present)
+--
+-- Business rules enforced by triggers:
+-- - A listing cannot be marked sold (is_sold=TRUE) unless sold_to_id is set.
+-- - A rating can only be inserted/updated if the listing is sold AND the rater is the buyer.
+-- - One rating per listing is enforced by UNIQUE(listing_id).
 
 CREATE TABLE account (
-  uuid         CHAR(36)     NOT NULL,
-  email        VARCHAR(255) NOT NULL,
-  passwords    VARCHAR(255) NOT NULL,   -- store a password hash, not plaintext
-  fname        VARCHAR(80)  NOT NULL,
-  lname        VARCHAR(80)  NOT NULL,
-  verified     BOOLEAN      NOT NULL DEFAULT FALSE,
-  PRIMARY KEY (uuid),
+  id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  -- Email is VARCHAR so we can enforce uniqueness efficiently with a standard UNIQUE index
+  email     VARCHAR(255)    NOT NULL,
+  -- Password should store a hash (bcrypt/argon2/etc.), kept as TEXT to avoid max-length constraints
+  password  TEXT            NOT NULL,
+  fname     TEXT            NOT NULL,
+  lname     TEXT            NOT NULL,
+  verified  BOOLEAN         NOT NULL DEFAULT FALSE,
+
+  PRIMARY KEY (id),
   UNIQUE KEY uq_account_email (email)
 ) ENGINE=InnoDB;
 
 CREATE TABLE listing (
-  id          BIGINT        NOT NULL AUTO_INCREMENT,
-  title       VARCHAR(200)  NOT NULL,
-  description TEXT          NULL,
-  image_url   TEXT          NULL,
-  price       DECIMAL(10,2) NOT NULL,
-  location    VARCHAR(200)  NULL,
-  created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  is_sold     BOOLEAN       NOT NULL DEFAULT FALSE,
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  -- Seller (poster) account id
+  seller_id   BIGINT UNSIGNED NOT NULL,
 
-  -- Posts relationship: Account (1) -> Listing (M)
-  seller_uuid CHAR(36)      NOT NULL,
+  title       TEXT NOT NULL,
+  description TEXT NOT NULL,
+  image_url   TEXT,
+  price       DECIMAL(10,2) NOT NULL,
+  location    TEXT,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- Marks whether the listing has been sold
+  is_sold     BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Buyer account id (must be set when is_sold is TRUE; enforced by trigger)
+  sold_to_id  BIGINT UNSIGNED NULL,
 
   PRIMARY KEY (id),
-  KEY idx_listing_seller (seller_uuid),
+
+  -- Indexes to speed up common queries:
+  -- - Fetch all listings by seller
+  -- - Fetch all listings bought by a buyer
+  -- - Sort or filter by created time and sold state
+  KEY idx_listing_seller_id (seller_id),
+  KEY idx_listing_sold_to_id (sold_to_id),
+  KEY idx_listing_created_at (created_at),
+  KEY idx_listing_is_sold (is_sold),
+
+  -- If a seller account is deleted, delete their listings
   CONSTRAINT fk_listing_seller
-    FOREIGN KEY (seller_uuid) REFERENCES account(uuid)
-    ON DELETE RESTRICT
+    FOREIGN KEY (seller_id) REFERENCES account(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  -- If a buyer account is deleted, delete listings where they were the recorded buyer
+  CONSTRAINT fk_listing_sold_to
+    FOREIGN KEY (sold_to_id) REFERENCES account(id)
+    ON DELETE CASCADE
     ON UPDATE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE offer (
-  id               BIGINT        NOT NULL AUTO_INCREMENT,
-  offered_price    DECIMAL(10,2) NOT NULL,
-  location_offered VARCHAR(200)  NULL,
-  created_date     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  seen             BOOLEAN       NOT NULL DEFAULT FALSE,
-  accepted         BOOLEAN       NOT NULL DEFAULT FALSE,
+  id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  offered_price    DECIMAL(10,2)   NOT NULL,
+  location_offered TEXT            NULL,
+  created_date     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  seen             BOOLEAN         NOT NULL DEFAULT FALSE,
+  -- Tri-state:
+  --   NULL  = pending
+  --   TRUE  = accepted
+  --   FALSE = rejected
+  accepted         BOOLEAN         NULL DEFAULT NULL,
 
-  -- Has relationship: Listing (1) -> Offer (M)
-  listing_id       BIGINT        NOT NULL,
+  -- Offer belongs to exactly one listing (Listing 1 -> Offer M)
+  listing_id       BIGINT UNSIGNED NOT NULL,
 
-  -- Send relationship: Account (1) -> Offer (M)
-  sender_uuid      CHAR(36)      NOT NULL,
+  -- Offer is sent by exactly one account (Account 1 -> Offer M)
+  sender_id        BIGINT UNSIGNED NOT NULL,
 
   PRIMARY KEY (id),
-  KEY idx_offer_listing (listing_id),
-  KEY idx_offer_sender (sender_uuid),
 
+  -- Indexes for fast lookups by listing and sender
+  KEY idx_offer_listing (listing_id),
+  KEY idx_offer_sender (sender_id),
+
+  -- If a listing is deleted, delete its offers
   CONSTRAINT fk_offer_listing
     FOREIGN KEY (listing_id) REFERENCES listing(id)
     ON DELETE CASCADE
     ON UPDATE CASCADE,
 
+  -- If a sender account is deleted, delete offers they sent
   CONSTRAINT fk_offer_sender
-    FOREIGN KEY (sender_uuid) REFERENCES account(uuid)
+    FOREIGN KEY (sender_id) REFERENCES account(id)
     ON DELETE CASCADE
     ON UPDATE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE comment (
-  id          BIGINT    NOT NULL AUTO_INCREMENT,
-  created_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  created_date DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-  -- (Body/text wasn’t shown clearly on the diagram, but comments usually need it.
-  --  Remove this column if you truly don’t want comment text.)
-  body        TEXT      NULL,
+  -- Comment text/body
+  body         TEXT            NULL,
 
-  -- Listing has Comment (M)
-  listing_id  BIGINT    NOT NULL,
+  -- Comment belongs to exactly one listing (Listing 1 -> Comment M)
+  listing_id   BIGINT UNSIGNED NOT NULL,
 
-  -- Account writes Comment (M)
-  author_uuid CHAR(36)  NOT NULL,
+  -- Comment is authored by exactly one account (Account 1 -> Comment M)
+  author_id    BIGINT UNSIGNED NOT NULL,
 
   PRIMARY KEY (id),
-  KEY idx_comment_listing (listing_id),
-  KEY idx_comment_author (author_uuid),
 
+  -- Indexes for fast lookups by listing and author
+  KEY idx_comment_listing (listing_id),
+  KEY idx_comment_author (author_id),
+
+  -- If a listing is deleted, delete its comments
   CONSTRAINT fk_comment_listing
     FOREIGN KEY (listing_id) REFERENCES listing(id)
     ON DELETE CASCADE
     ON UPDATE CASCADE,
 
+  -- If an author account is deleted, delete their comments
   CONSTRAINT fk_comment_author
-    FOREIGN KEY (author_uuid) REFERENCES account(uuid)
+    FOREIGN KEY (author_id) REFERENCES account(id)
     ON DELETE CASCADE
     ON UPDATE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE rating (
-  id                 BIGINT    NOT NULL AUTO_INCREMENT,
-  created_at         DATETIME  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  transaction_rating INT       NOT NULL,
+  id                 BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  created_at         DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  transaction_rating INT             NOT NULL,
 
-  -- Listing gets Rating (M)
-  listing_id         BIGINT    NOT NULL,
+  -- Rating is associated with a listing
+  listing_id         BIGINT UNSIGNED NOT NULL,
+  -- Rating is created by an account (must be the buyer; enforced by trigger)
+  rater_id           BIGINT UNSIGNED NOT NULL,
 
   PRIMARY KEY (id),
-  KEY idx_rating_listing (listing_id),
 
-  CONSTRAINT chk_rating_range
-    CHECK (transaction_rating BETWEEN 1 AND 5),
+  -- Enforces ONE rating per listing (since there is only one buyer for a listing)
+  UNIQUE KEY uq_rating_one_per_listing (listing_id),
+  -- Helps query "all ratings by a user"
+  KEY idx_rating_rater (rater_id),
 
+  -- If a listing is deleted, delete its rating
   CONSTRAINT fk_rating_listing
     FOREIGN KEY (listing_id) REFERENCES listing(id)
     ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  -- If the rater account is deleted, delete their rating(s)
+  CONSTRAINT fk_rating_rater
+    FOREIGN KEY (rater_id) REFERENCES account(id)
+    ON DELETE CASCADE
     ON UPDATE CASCADE
 ) ENGINE=InnoDB;
+
+-- =========================================================
+-- Triggers for business rules enforcement
+-- =========================================================
+
+DELIMITER $$
+
+-- Enforce: listing must be sold AND rater must be the buyer before inserting a rating
+CREATE TRIGGER trg_rating_only_buyer_ins
+BEFORE INSERT ON rating
+FOR EACH ROW
+BEGIN
+  DECLARE buyer_id BIGINT UNSIGNED;
+  DECLARE sold_flag BOOLEAN;
+
+  -- Look up the buyer and sold state from the listing
+  SELECT sold_to_id, is_sold
+    INTO buyer_id, sold_flag
+  FROM listing
+  WHERE id = NEW.listing_id;
+
+  -- Cannot rate an unsold listing
+  IF sold_flag = FALSE OR buyer_id IS NULL THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Cannot rate: listing not sold';
+  END IF;
+
+  -- Only the buyer can rate the listing
+  IF NEW.rater_id <> buyer_id THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Only the buyer can rate this listing';
+  END IF;
+END$$
+
+-- Enforce the same rule on updates (prevents changing rater_id to someone else, etc.)
+CREATE TRIGGER trg_rating_only_buyer_upd
+BEFORE UPDATE ON rating
+FOR EACH ROW
+BEGIN
+  DECLARE buyer_id BIGINT UNSIGNED;
+  DECLARE sold_flag BOOLEAN;
+
+  SELECT sold_to_id, is_sold
+    INTO buyer_id, sold_flag
+  FROM listing
+  WHERE id = NEW.listing_id;
+
+  IF sold_flag = FALSE OR buyer_id IS NULL THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Cannot rate: listing not sold';
+  END IF;
+
+  IF NEW.rater_id <> buyer_id THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Only the buyer can rate this listing';
+  END IF;
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+
+-- Enforce: if a listing is marked sold, a buyer must be provided
+CREATE TRIGGER trg_listing_sold_requires_buyer
+BEFORE UPDATE ON listing
+FOR EACH ROW
+BEGIN
+  IF NEW.is_sold = TRUE AND NEW.sold_to_id IS NULL THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'sold_to_id must be set when is_sold is TRUE';
+  END IF;
+END$$
+
+DELIMITER ;

--- a/persistence/db/seed_dev.sql
+++ b/persistence/db/seed_dev.sql
@@ -15,118 +15,159 @@ SET FOREIGN_KEY_CHECKS = 1;
 
 -- =========================================
 -- ACCOUNTS
+-- - id is AUTO_INCREMENT (do NOT insert it)
+-- - email is UNIQUE
+-- - password stored as TEXT (demo only)
 -- =========================================
 
-INSERT INTO account (uuid, email, passwords, fname, lname, verified) VALUES
-(UUID(), 'alice@example.com',   SHA2('password123',256), 'Alice',   'Johnson', TRUE),
-(UUID(), 'bob@example.com',     SHA2('password123',256), 'Bob',     'Smith', TRUE),
-(UUID(), 'carol@example.com',   SHA2('password123',256), 'Carol',   'Brown', FALSE),
-(UUID(), 'david@example.com',   SHA2('password123',256), 'David',   'Wilson', TRUE),
-(UUID(), 'emma@example.com',    SHA2('password123',256), 'Emma',    'Taylor', TRUE),
-(UUID(), 'mohamed@example.com', SHA2('password123',256), 'Mohamed', 'Youssef', TRUE),
-(UUID(), 'liam@example.com',    SHA2('password123',256), 'Liam',    'Miller', FALSE),
-(UUID(), 'olivia@example.com',  SHA2('password123',256), 'Olivia',  'Davis', TRUE),
-(UUID(), 'noah@example.com',    SHA2('password123',256), 'Noah',    'Clark', TRUE),
-(UUID(), 'sophia@example.com',  SHA2('password123',256), 'Sophia',  'Lewis', TRUE);
+INSERT INTO account (email, password, fname, lname, verified) VALUES
+('alice@example.com',   'password123', 'Alice',   'Johnson', TRUE),
+('bob@example.com',     'password123', 'Bob',     'Smith',   TRUE),
+('carol@example.com',   'password123', 'Carol',   'Brown',   FALSE),
+('david@example.com',   'password123', 'David',   'Wilson',  TRUE),
+('emma@example.com',    'password123', 'Emma',    'Taylor',  TRUE),
+('mohamed@example.com', 'password123', 'Mohamed', 'Youssef', TRUE),
+('liam@example.com',    'password123', 'Liam',    'Miller',  FALSE),
+('olivia@example.com',  'password123', 'Olivia',  'Davis',   TRUE),
+('noah@example.com',    'password123', 'Noah',    'Clark',   TRUE),
+('sophia@example.com',  'password123', 'Sophia',  'Lewis',   TRUE);
+
 
 -- =========================================
 -- LISTINGS
+-- - seller_id references account(id)
+-- - sold_to_id is NULL initially (not sold yet)
 -- =========================================
 
-INSERT INTO listing (title, description, image_url, price, location, seller_uuid)
+INSERT INTO listing (title, description, image_url, price, location, seller_id)
 SELECT
-    'iPhone 13 Pro',
-    'Great condition, barely used.',
-    'https://example.com/img1.jpg',
-    850.00,
-    'Winnipeg',
-    uuid
-FROM account ORDER BY RAND() LIMIT 1;
+  'iPhone 13 Pro',
+  'Great condition, barely used.',
+  'https://example.com/img1.jpg',
+  850.00,
+  'Winnipeg',
+  a.id
+FROM account a
+ORDER BY RAND()
+LIMIT 1;
 
-INSERT INTO listing (title, description, image_url, price, location, seller_uuid)
+INSERT INTO listing (title, description, image_url, price, location, seller_id)
 SELECT
-    'Gaming Laptop',
-    'RTX graphics, 16GB RAM.',
-    'https://example.com/img2.jpg',
-    1200.00,
-    'Toronto',
-    uuid
-FROM account ORDER BY RAND() LIMIT 1;
+  'Gaming Laptop',
+  'RTX graphics, 16GB RAM.',
+  'https://example.com/img2.jpg',
+  1200.00,
+  'Toronto',
+  a.id
+FROM account a
+ORDER BY RAND()
+LIMIT 1;
 
-INSERT INTO listing (title, description, image_url, price, location, seller_uuid)
+INSERT INTO listing (title, description, image_url, price, location, seller_id)
 SELECT
-    'Office Chair',
-    'Ergonomic and comfortable.',
-    'https://example.com/img3.jpg',
-    150.00,
-    'Vancouver',
-    uuid
-FROM account ORDER BY RAND() LIMIT 1;
+  'Office Chair',
+  'Ergonomic and comfortable.',
+  'https://example.com/img3.jpg',
+  150.00,
+  'Vancouver',
+  a.id
+FROM account a
+ORDER BY RAND()
+LIMIT 1;
 
-INSERT INTO listing (title, description, image_url, price, location, seller_uuid)
+INSERT INTO listing (title, description, image_url, price, location, seller_id)
 SELECT
-    'Mountain Bike',
-    'Lightweight aluminum frame.',
-    'https://example.com/img4.jpg',
-    600.00,
-    'Calgary',
-    uuid
-FROM account ORDER BY RAND() LIMIT 1;
+  'Mountain Bike',
+  'Lightweight aluminum frame.',
+  'https://example.com/img4.jpg',
+  600.00,
+  'Calgary',
+  a.id
+FROM account a
+ORDER BY RAND()
+LIMIT 1;
 
 -- =========================================
 -- OFFERS
+-- - offer.sender_id references account(id)
+-- - sender must NOT be the seller
+-- - accepted is tri-state: NULL = pending
 -- =========================================
 
-INSERT INTO offer (offered_price, location_offered, listing_id, sender_uuid)
+INSERT INTO offer (offered_price, location_offered, listing_id, sender_id, accepted)
 SELECT
-    ROUND(l.price * (0.7 + RAND()*0.2), 2),
-    l.location,
-    l.id,
-    a.uuid
+  ROUND(l.price * (0.7 + RAND()*0.2), 2),
+  l.location,
+  l.id,
+  a.id,
+  NULL
 FROM listing l
-JOIN account a ON a.uuid != l.seller_uuid
+JOIN account a ON a.id <> l.seller_id
 ORDER BY RAND()
 LIMIT 8;
 
 -- =========================================
 -- COMMENTS
+-- - comment.author_id references account(id)
+-- - author must NOT be the seller (optional rule, but realistic)
 -- =========================================
 
-INSERT INTO comment (body, listing_id, author_uuid)
+INSERT INTO comment (body, listing_id, author_id)
 SELECT
-    'Is this still available?',
-    l.id,
-    a.uuid
+  'Is this still available?',
+  l.id,
+  a.id
 FROM listing l
-JOIN account a ON a.uuid != l.seller_uuid
+JOIN account a ON a.id <> l.seller_id
 ORDER BY RAND()
 LIMIT 6;
 
-INSERT INTO comment (body, listing_id, author_uuid)
+INSERT INTO comment (body, listing_id, author_id)
 SELECT
-    'Can you lower the price?',
-    l.id,
-    a.uuid
+  'Can you lower the price?',
+  l.id,
+  a.id
 FROM listing l
-JOIN account a ON a.uuid != l.seller_uuid
+JOIN account a ON a.id <> l.seller_id
 ORDER BY RAND()
 LIMIT 6;
 
 -- =========================================
--- RATINGS
+-- MARK SOME LISTINGS AS SOLD
+-- IMPORTANT:
+-- - trigger requires: if is_sold=TRUE then sold_to_id IS NOT NULL
+-- - Buyer must be different from seller (logical)
 -- =========================================
 
-INSERT INTO rating (transaction_rating, listing_id)
+UPDATE listing l
+JOIN (
+  SELECT
+    l2.id AS listing_id,
+    a2.id AS buyer_id
+  FROM listing l2
+  JOIN account a2 ON a2.id <> l2.seller_id
+  ORDER BY RAND()
+  LIMIT 2
+) t ON t.listing_id = l.id
+SET
+  l.is_sold = TRUE,
+  l.sold_to_id = t.buyer_id;
+
+-- =========================================
+-- RATINGS (buyer-only)
+-- IMPORTANT:
+-- - UNIQUE(listing_id) => at most one rating per listing
+-- - Trigger requires:
+--     1) listing is sold
+--     2) rater_id = listing.sold_to_id
+-- So we ONLY insert ratings for sold listings and set rater_id = sold_to_id
+-- =========================================
+
+INSERT INTO rating (transaction_rating, listing_id, rater_id)
 SELECT
-    FLOOR(1 + RAND()*5),
-    id
-FROM listing;
-
--- =========================================
--- OPTIONAL: MARK RANDOM LISTING AS SOLD
--- =========================================
-
-UPDATE listing
-SET is_sold = TRUE
-ORDER BY RAND()
-LIMIT 1;
+  FLOOR(1 + RAND()*5),
+  l.id,
+  l.sold_to_id
+FROM listing l
+WHERE l.is_sold = TRUE
+  AND l.sold_to_id IS NOT NULL;


### PR DESCRIPTION
…-only ratings

- Migrated Account from UUID (CHAR(36)) to BIGINT UNSIGNED AUTO_INCREMENT (id)
- Updated all foreign keys to reference account(id)
- Added sold_to_id to listing to represent buyer relationship
- Implemented full ON DELETE CASCADE / ON UPDATE CASCADE across all relations
- Enforced one rating per listing via UNIQUE(listing_id)
- Added triggers to: • Prevent rating unless listing is sold • Ensure only the buyer (sold_to_id) can rate • Require sold_to_id when marking a listing as sold
- Updated Offer.accepted to tri-state (NULL = pending, TRUE = accepted, FALSE = rejected)
- Refactored seed data to align with the new schema design

Refs: #86, #82

## Description

<!--
What does this PR do?
Why is this change needed?
Link related tickets or issues (Jira/GitHub).
-->

---

## Screenshots / Recordings

<!--
Add screenshots, logs, or recordings if applicable.
Remove this section if not relevant.
-->

---

## Checklist

### Testing

[ ] Unit tests written  
[ ] Integration tests written (if applicable)  
[ ] All tests pass locally

### Verification

[ ] Ran tests before merging  
[ ] No breaking changes introduced  
[ ] Code follows project standards

---

## Additional Notes

<!--
Anything reviewers should pay extra attention to?
Edge cases, trade-offs, or follow-ups?
-->
## Related Issues
Closes #86