### PR TITLE
BUG: fix cd pipeline to refer to the exact commit that passed this CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # --- Docker ---
-DOCKER_USERNAME=yourusername
+DOCKER_USERNAME=marketsafe
 
 # --- Security ---
 SECRET_KEY=change-me

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3 # Enables building multi-platform images


### PR DESCRIPTION
## Description

Without ref: ${{ github.event.workflow_run.head_sha }}, GitHub checks out whatever is currently at the tip of the branch in the CD workflow's own context, which can lag behind or differ from the commit that actually ran CI. Adding that ref ensures the Docker images are built from the exact commit that passed CI.

---

## Screenshots / Recordings

<!--
Add screenshots, logs, or recordings if applicable.
Remove this section if not relevant.
-->

---

## Checklist

### Testing

[ ] Unit tests written  
[ ] Integration tests written (if applicable)  
[ ] All tests pass locally

### Verification

[ ] Ran tests before merging  
[ ] No breaking changes introduced  
[ ] Code follows project standards

---

## Additional Notes

<!--
Anything reviewers should pay extra attention to?
Edge cases, trade-offs, or follow-ups?
-->
