### PR TITLE
REFACTOR: Exclude Frontend and Tests files in SonarQube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,8 @@
 sonar.projectKey=MarketSafe-4350_MarketSafe
 sonar.organization=marketsafe-4350
 
-sonar.sources=.
+sonar.sources=server
+sonar.exclusions=**/tests/**,frontend/**
+sonar.coverage.exclusions=**/tests/**,frontend/**
 sonar.python.coverage.reportPaths=server/coverage.xml
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Three changes:                                         
  - sonar.sources=server — only analyze the server directory
  - sonar.exclusions — exclude test files and frontend from analysis            
  - sonar.coverage.exclusions — exclude test files and frontend from coverage   
  metrics   

Closes #237 

## Description

<!--
What does this PR do?
Why is this change needed?
Link related tickets or issues (Jira/GitHub).
-->

---

## Screenshots / Recordings

<!--
Add screenshots, logs, or recordings if applicable.
Remove this section if not relevant.
-->

---

## Checklist

### Testing

[ ] Unit tests written  
[ ] Integration tests written (if applicable)  
[ ] All tests pass locally

### Verification

[ ] Ran tests before merging  
[ ] No breaking changes introduced  
[ ] Code follows project standards

---

## Additional Notes

<!--
Anything reviewers should pay extra attention to?
Edge cases, trade-offs, or follow-ups?
-->
